### PR TITLE
Add OpID tracking support (and slf4j dependencies).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,5 +43,11 @@
 			<version>2.5</version>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-log4j12</artifactId>
+		    <version>1.7.21</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/com/vmware/vim25/ws/SoapConsts.java
+++ b/src/main/java/com/vmware/vim25/ws/SoapConsts.java
@@ -37,6 +37,11 @@ public class SoapConsts
   final public static Namespace XSI = new Namespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
   final public static QName XSI_TYPE = new QName("type", XSI);
 
-  final public static String SOAP_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soapenv:Envelope xmlns:soapenc=\"http://schemas.xmlsoap.org/soap/encoding/\" xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><soapenv:Body>"; 
+  final public static String SOAP_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+    " <soapenv:Envelope xmlns:soapenc=\"http://schemas.xmlsoap.org/soap/encoding/\"" +
+    " xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\"" +
+    " xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"" +
+    " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">";
+  final public static String SOAP_BODY = "<soapenv:Body>";
   final public static String SOAP_END = "</soapenv:Body></soapenv:Envelope>";
 }


### PR DESCRIPTION
OperationID's are very useful in tracing the request from client
to vcenter (vpxd) to esx host (hostd/vpxa) and other servers.
OpID's can also be logged from the client using log4j infrastructure.
VMware servers already log these in their logs. Here is a sample
log from vpxd, using an automatically generated OpID.

>tail -f  vpxd.log  | grep -i vijava
2016-08-16T18:23:41.822Z verbose vpxd[7FB1BA4DD700] [Originator@6876 sub=Default opID=ViJava-53abd420-68] [VpxVmomi] Invoking [retrieveContent] on [vim.ServiceInstance:ServiceInstance] session [524db190-383e-3650-3499-ba9b90e347cc]
2016-08-16T18:23:41.822Z info vpxd[7FB1BACED700] [Originator@6876 sub=vpxLro opID=ViJava-53abd420-68] [VpxLRO] -- BEGIN task-internal-759372 -- ServiceInstance -- vim.ServiceInstance.retrieveContent -- 524db190-383e-3650-3499-ba9b90e347cc
2016-08-16T18:23:41.823Z verbose vpxd[7FB1BACED700] [Originator@6876 sub=Default opID=ViJava-53abd420-68] [VpxVmomi] Invoke done: vim.ServiceInstance.retrieveContent session: 524db190-383e-3650-3499-ba9b90e347cc
2016-08-16T18:23:41.823Z info vpxd[7FB1BACED700] [Originator@6876 sub=vpxLro opID=ViJava-53abd420-68] [VpxLRO] -- FINISH task-internal-759372 2016-08-16T18:23:41.872Z verbose vpxd[7FB1BA6E1700] [Originator@6876 sub=Default opID=ViJava-53abd420-30] [VpxVmomi] Invoking [retrieveContent] on [vim.ServiceInstance:ServiceInstance] session [52174783-8f5a-ed8e-4338-b3a4a4684dbf]
2016-08-16T18:23:41.872Z info vpxd[7FB1C02C2700] [Originator@6876 sub=vpxLro opID=ViJava-53abd420-30] [VpxLRO] -- BEGIN task-internal-759373 -- ServiceInstance -- vim.ServiceInstance.retrieveContent -- 52174783-8f5a-ed8e-4338-b3a4a4684dbf
2016-08-16T18:23:41.872Z verbose vpxd[7FB1C02C2700] [Originator@6876 sub=Default opID=ViJava-53abd420-30] [VpxVmomi] Invoke done: vim.ServiceInstance.retrieveContent session: 52174783-8f5a-ed8e-4338-b3a4a4684dbf
2016-08-16T18:23:41.873Z info vpxd[7FB1C02C2700] [Originator@6876 sub=vpxLro opID=ViJava-53abd420-30] [VpxLRO] -- FINISH task-internal-759373
2016-08-16T18:23:41.883Z verbose vpxd[7FB1BA4DD700] [Originator@6876 sub=Default opID=ViJava-53abd420-f3] [VpxVmomi] Invoking [login] on [vim.SessionManager:SessionManager] session [520ab81d-8188-81cc-0e85-304326dcd4cb]
2016-08-16T18:23:41.883Z info vpxd[7FB1C00BE700] [Originator@6876 sub=vpxLro opID=ViJava-53abd420-f3] [VpxLRO] -- BEGIN task-internal-759374 -- SessionManager -- vim.SessionManager.login -- 520ab81d-8188-81cc-0e85-304326dcd4cb
...